### PR TITLE
Follow Uber guide style

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -94,7 +94,7 @@ func (a *Agent) listen() error {
 	}, backoff.WithContext(retry, ctx))
 
 	if err != nil {
-		return errors.Wrap(err, "fail to subscribe to stream")
+		return errors.Wrap(err, "subscribe to stream")
 	}
 
 	log.WithFields(log.Fields{"hub": a.hubURL()}).Info("agent: listening")

--- a/pkg/agent/player.go
+++ b/pkg/agent/player.go
@@ -21,7 +21,7 @@ func (a *Agent) replay(requestID string, data []byte) {
 	var request dto.Request
 
 	if err := json.Unmarshal(data, &request); err != nil {
-		log.Error(errors.Wrap(err, "Failed to parse Request"))
+		log.Error(errors.Wrap(err, "parse Request"))
 		return
 	}
 
@@ -60,6 +60,6 @@ func (a *Agent) replay(requestID string, data []byte) {
 	})
 
 	if err != nil {
-		log.WithFields(log.Fields{"requestID": requestID}).Error(errors.Wrap(err, "unable to replay request"))
+		log.WithFields(log.Fields{"requestID": requestID}).Error(errors.Wrap(err, "replay request"))
 	}
 }

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -147,7 +147,7 @@ func NewOptionsFromEnv() (*Options, error) {
 		},
 	}
 
-	missingEnv := []string{}
+	var missingEnv []string
 	if options.Hub.Endpoint == nil {
 		missingEnv = append(missingEnv, "HUB_ENDPOINT")
 	}

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -25,7 +25,7 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 	// serializing original request
 	data, err := json.Marshal(request)
 	if err != nil {
-		log.Error(errors.Wrap(err, "Failed to encode Request"))
+		log.Error(errors.Wrap(err, "encode Request"))
 		w.WriteHeader(http.StatusInternalServerError)
 
 		return
@@ -52,7 +52,7 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 	// pushing request to hub
 	hubResponse, err := s.hubClient.Do(hubRequest)
 	if err != nil {
-		log.Error(errors.Wrap(err, "Server: Failed to push record"))
+		log.Error(errors.Wrap(err, "push record"))
 	}
 
 	if hubResponse.StatusCode >= 400 {

--- a/pkg/server/middleware/loopguard/loop_guard.go
+++ b/pkg/server/middleware/loopguard/loop_guard.go
@@ -19,8 +19,10 @@ type LoopGuard struct {
 }
 
 func (l *LoopGuard) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	tokens := []string{}
-	contains := false
+	var (
+		tokens   []string
+		contains = false
+	)
 
 	for _, token := range strings.Split(r.Header.Get(guardHeader), ",") {
 		if token = strings.TrimSpace(token); token != "" {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -143,7 +143,7 @@ func (s *Server) startAcmeServer() {
 
 	ln, err := net.Listen("tcp", s.options.Server.TLS.AcmeAddr)
 	if err != nil {
-		log.Error(errors.Wrap(err, "fail to start acme server"))
+		log.Error(errors.Wrap(err, "start acme server"))
 	}
 
 	log.WithFields(log.Fields{"hosts": s.options.Server.TLS.AcmeHosts, "addr": s.options.Server.TLS.AcmeAddr}).Info("server: acme server listening")


### PR DESCRIPTION
Following Uber style guide in https://github.com/uber-go/guide/blob/master/style.md#uber-go-style-guide

This PR:
- removes `fail to.. ` in errors wraping
- groups similar var
- don't use make to create empty slice