### PR TITLE
Fix nil pointer exception when request failed

### DIFF
--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -55,7 +55,7 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		log.Error(errors.Wrap(err, "push record"))
 	}
 
-	if hubResponse.StatusCode >= http.StatusBadRequest {
+	if hubResponse != nil && hubResponse.StatusCode >= http.StatusBadRequest {
 		defer hubResponse.Body.Close()
 		respStr, _ := httputil.DumpResponse(hubResponse, true)
 


### PR DESCRIPTION
This PR partialy fixes #22 by fixing the nil pointer exception in case th request to the hub failed